### PR TITLE
Change the npm to npx

### DIFF
--- a/src/pages/index.svelte
+++ b/src/pages/index.svelte
@@ -16,6 +16,6 @@
 			<li>No need to proxy authentication through a server</li>
 		</ul>
 				
-		<code>npm @sveltech/routify init --branch auth</code>
+		<code>npx @sveltech/routify init --branch auth</code>
 	</div>
 </div>


### PR DESCRIPTION
To install template, we use `npx`, not `npm`. I think it's just a typo.